### PR TITLE
retains port info for local siteurl

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -80,7 +80,7 @@ class Helpers {
 
 		/** Remove www. */
 		$url_parts = parse_url( $url );
-		$domain = preg_replace( '/^www\./', '', $url_parts['host'] ) . ":" . $url_parts["port"];
+		$domain = preg_replace( '/^www\./', '', $url_parts['host'] ) . ( ! empty( $url_parts['port'] ) ? ':' . $url_parts['port'] : '' );
 
 		/** Add directory path if needed **/
 		if ( $path && $url_parts['path'] )


### PR DESCRIPTION
Firstly, thanks for making this plugin. I've been taking over some WP projects lately, coming from Rails/Python, and have been frustrated by how manual everything is. Am working on automating deployment, so loving this plugin.

My use case might be niche. I've been using a Vagrant VM as my local development Wordpress server, which has VM port 80 mapped to my computer's port 8080. As such, my site urls for local dev are http://localhost:8080.

Running wp deploy push staging strips the port before search-and-replace, so my staging URLs look like http://domain/sub-domain:8080/. I wanted to fix this.

The port-stripping happens in helpers.php, in the trim_url function, when the url is parsed, and only the domain is retained. Link here.

I forked the repo and kept the port for my own purposes. Currently, I've hardcoded to always keep port info, but could easily move it do a config param. I've opened this PR to show you what I mean. Feel free to close the issue without merging if you don't think it's a big deal.

Cheers
