### PR TITLE
Refine the mysqldump command

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -537,15 +537,11 @@ class WP_Deploy_Command extends WP_CLI_Command {
 
 		$runner = self::$runner;
 
-		$foo = "ssh $c->ssh -p $c->port 'mkdir -p $c->path; cd $c->path;"
-			. " mysqldump --user=$c->db_user --password=\"$c->db_password\" --host=$c->db_host"
-			. " --single-transaction"
-			. " --add-drop-table $c->db_name > $server_file'";
-
-		echo $foo;
-
 		$runner->add(
-			$foo,
+			"ssh $c->ssh -p $c->port 'mkdir -p $c->path; cd $c->path;"
+			. " mysqldump --user=$c->db_user --password=\"" . escapeshellcmd( $c->db_password ) . "\" --host=$c->db_host"
+			. " --single-transaction"
+			. " --add-drop-table $c->db_name > $server_file'",
 			"Dumped the remote database to '$c->path/$server_file' on the server.",
 			'Failed dumping the remote database.'
 		);


### PR DESCRIPTION
### Issue 1

The original mysql command was failing on a couple of servers with the error:
`MySQL: Access denied when using LOCK TABLES`

Table locking can be avoided by forcing a single transaction for the dump, i.e. specifying the `--single-transaction` parameter to `mysqldump`.
### Issue 2

The password is passed directly in the command line, and can contain characters that interfere with bash, such as `$`. Pass it through the builtin PHP function `escapeshellcmd` to avoid these problems.
