### PR TITLE
use escapeshellarg to escape database password

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -438,7 +438,7 @@ class WP_Deploy_Command extends WP_CLI_Command {
 
 		$runner->add(
 			"ssh $c->ssh -p $c->port 'cd $c->path;"
-			. " mysql --user=$c->db_user --password=\"$c->db_password\" --host=$c->db_host"
+			. " mysql --user=$c->db_user --password=" . escapeshellarg( $c->db_password ) ." --host=$c->db_host"
 			. " $c->db_name < $server_file'",
 			'Deployed the database on server.',
 			'Failed deploying the db on server.'
@@ -539,7 +539,7 @@ class WP_Deploy_Command extends WP_CLI_Command {
 
 		$runner->add(
 			"ssh $c->ssh -p $c->port 'mkdir -p $c->path; cd $c->path;"
-			. " mysqldump --user=$c->db_user --password=\"" . escapeshellcmd( $c->db_password ) . "\" --host=$c->db_host"
+			. " mysqldump --user=$c->db_user --password=" . escapeshellarg( $c->db_password ) . " --host=$c->db_host"
 			. " --single-transaction"
 			. " --add-drop-table $c->db_name > $server_file'",
 			"Dumped the remote database to '$c->path/$server_file' on the server.",


### PR DESCRIPTION
I was having issues with `escapeshellcmd` and a strong database password. Changing to the more appropriate `escapeshellarg` fixes the issue.

May be worth adding to other arguments as well.