### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "c10b10/wp-cli-deploy",
     "description": "Deploys the local WordPress database or the uploads directory to a remote server using ssh.",
+    "type": "wp-cli-package",
     "keywords": ["wp-cli", "git", "deploy", "dump", "mysql", "uploads", "wordpress"],
     "homepage": "https://github.com/c10b10/wp-cli-deploy",
     "license": "MIT",


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
